### PR TITLE
Implement sphinx only

### DIFF
--- a/outputs/document/build.dac
+++ b/outputs/document/build.dac
@@ -6,6 +6,7 @@ function process {
     local source_folder=$2
     local destination_folder=$3
     local filename=$4
+    local version=$5
 
     local cmd_args=()
     cmd_args+=(-a doctype=book)
@@ -40,7 +41,7 @@ function process {
 
     cmd_args+=(-o $destination_folder/$output_file_prefix$filename.pdf)
     
-    2asciidoc.sh $input_file $source_folder/.$filename.adoc
+    2asciidoc.sh $input_file $source_folder/.$filename.adoc $version
 
     asciidoctor-pdf "${cmd_args[@]}" "$source_folder/.$filename.adoc"
 

--- a/outputs/note/build.dac
+++ b/outputs/note/build.dac
@@ -6,6 +6,7 @@ function process {
     local source_folder=$2
     local destination_folder=$3
     local filename=$4
+    local version=$5
 
     local cmd_args=()
     cmd_args+=(-a doctype=article)
@@ -39,7 +40,7 @@ function process {
 
     cmd_args+=(-o $destination_folder/$output_file_prefix$filename.pdf)
     
-    2asciidoc.sh $input_file $source_folder/.$filename.adoc
+    2asciidoc.sh $input_file $source_folder/.$filename.adoc $version
 
     asciidoctor-pdf "${cmd_args[@]}" "$source_folder/.$filename.adoc"
 

--- a/outputs/slides/build.dac
+++ b/outputs/slides/build.dac
@@ -6,6 +6,7 @@ function process {
     local source_folder=$2
     local destination_folder=$3
     local filename=$4
+    local version=$5
 
     local cmd_args=()
     cmd_args+=(-a doctype=book)
@@ -39,7 +40,7 @@ function process {
 
     cmd_args+=(-o $destination_folder/$output_file_prefix$filename.pdf)
     
-    2asciidoc.sh $input_file $source_folder/.$filename.adoc
+    2asciidoc.sh $input_file $source_folder/.$filename.adoc $version
 
     asciidoctor-pdf "${cmd_args[@]}" "$source_folder/.$filename.adoc"
 

--- a/outputs/slides/html/build.dac
+++ b/outputs/slides/html/build.dac
@@ -6,6 +6,7 @@ function process {
     local source_folder=$2
     local destination_folder=$3
     local filename=$4
+    local version=$5
 
     custom_destination_folder=$destination_folder/slidesHTML/
     local options_higlighter='-a source-highlighter=highlightjs'
@@ -13,7 +14,7 @@ function process {
     local options_style='-a customcss=/tmp/buildir/custom.css -a imagesoutdir='$custom_destination_folder/'/'
     local options_output='-o '$custom_destination_folder/$filename'.html'
 
-    2asciidoc.sh $input_file $source_folder/.$filename.adoc
+    2asciidoc.sh $input_file $source_folder/.$filename.adoc $version
     
     # replace line break with revealjs specific lb
     sed -i -e "s/<<</== !/g" $source_folder/.$filename.adoc

--- a/scripts/docsascode/2asciidoc.sh
+++ b/scripts/docsascode/2asciidoc.sh
@@ -1,6 +1,8 @@
 #! /bin/bash
 # set -xe
 
+source yq_functions.sh
+
 if [ "$#" -ne 2 ]; then
     echo "Illegal number of parameters"
     exit -1
@@ -37,22 +39,30 @@ case "$1" in
         cd $currenttmpdir
         pandoc -s -f rst -t rst $filenametmp -o $2.tmp
         sed -i -e "s/\.\. container:: newslide/<<</g" $2.tmp
-        
-        sed -i -e "s/^[ \t]*.. container:: sliderow/$twoColsStart/g" $2.tmp
-        sed -i -e "s/^[ \t]*.. container:: slidecol/$twoColsRow/g" $2.tmp
-        sed -i -e "s/^[ \t]*.. container:: endsliderow/$twoColsEnd/g" $2.tmp
 
-        sed -i -e "s/^[ \t]*.. container:: 2cols/$twoColsStart/g" $2.tmp
-        sed -i -e "s/^[ \t]*.. container:: newcol/$twoColsRow/g" $2.tmp
-        sed -i -e "s/^[ \t]*.. container:: end_2cols/$twoColsEnd/g" $2.tmp        
-        
+        sed -i -e "s/^\([ \t]*\).. container:: sliderow/\1$twoColsStart/g" $2.tmp
+        sed -i -e "s/^\([ \t]*\).. container:: slidecol/\1$twoColsRow/g" $2.tmp
+        sed -i -e "s/^\([ \t]*\).. container:: endsliderow/\1$twoColsEnd/g" $2.tmp
+
+        sed -i -e "s/^\([ \t]*\).. container:: 2cols/\1$twoColsStart/g" $2.tmp
+        sed -i -e "s/^\([ \t]*\).. container:: newcol/\1$twoColsRow/g" $2.tmp
+        sed -i -e "s/^\([ \t]*\).. container:: end_2cols/\1$twoColsEnd/g" $2.tmp        
+
         sed -i -e "s/:download:\`\(.*\)\`/\`\1\`_/g" $2.tmp
+
         pandoc -s -f rst -t asciidoc $2.tmp -o $2
         rm -f $2.tmp 
         # go back into working dir
         cd $workingdir
         # fix attributes bad convertion
         sed -i -e "s/\\\{/{/g" $2
+        # remove text bloc title
+        sed -i -e "/^\.Note/d" $2
+        sed -i -e "/^\.Warning/d" $2
+        sed -i -e "/^\.Tip/d" $2
+        sed -i -e "/^\.Caution/d" $2
+        sed -i -e "/^\.Important/d" $2
+
         ;;
 *.adoc )
         cp $1 $2
@@ -72,10 +82,12 @@ rm -f $tmpfile
 sed -i "s/^image:\([^:].*\)\[\([^]]*\)\]$/image::\1[\2]/g" $2
 
 # manage multi columns
-sed -i -e "s/$twoColsStart/\[cols=2*a,%autowidth.stretch,frame=none,grid=none,stripes=none\]\n|===/g" $2
-sed -i -e "s/$twoColsRow/|/g" $2
-sed -i -e "s/$twoColsEnd/\|===/g" $2
+sed -i -e "s/\([ \t]*\)$twoColsStart/\1\[cols=2*a,%autowidth.stretch,frame=none,grid=none,stripes=none\]\n|===/g" $2
+sed -i -e "s/\([ \t]*\)$twoColsRow/\1|/g" $2
+sed -i -e "s/\([ \t]*\)$twoColsEnd/\1|===/g" $2
 sed -i -e '/^____/d' $2
+sed -i ':a;N;$!ba;s/--\n|/|/g' $2
+sed -i ':a;N;$!ba;s/--\n\n|==/|==/g' $2
 
 # clear diagram blocs
 sed -i -e "s/\[source,graphviz/\[graphviz/g" $2
@@ -86,6 +98,7 @@ sed -i -e "s/\[source,vegalite/\[vegalite/g" $2
 sed -i -e "s/\[source,vega/\[vega/g" $2
 
 # force break before subtitles
+# echo $(readVarInYml $default_tmp_builddir/full.yml heading.h2.breakbefore)
 # if [ ! -z heading_h2_breakbefore ] && [ '$heading_h2_breakbefore'  = true ]; then sed -i -e 's/^== /<<<\n== /g' $2 ; fi
 # if [ ! -z heading_h3_breakbefore ] && [ '$heading_h3_breakbefore'  = true ]; then sed -i -e 's/^=== /<<<\n=== /g' $2 ; fi
 # if [ ! -z heading_h4_breakbefore ] && [ '$heading_h4_breakbefore'  = true ]; then sed -i -e 's/^==== /<<<\n==== /g' $2 ; fi

--- a/scripts/docsascode/2asciidoc.sh
+++ b/scripts/docsascode/2asciidoc.sh
@@ -51,13 +51,9 @@ case "$1" in
         sed -i -e "s/:download:\`\(.*\)\`/\`\1\`_/g" $2.tmp
 
         sed -i "/container:: only/{
-          :a;N;/container:: endonly/!ba;/$3/p;s/.. container:: only\n\n   $3\n\(.*\)\n.*/\1/}" $2.tmp
+          :a;N;/container:: endonly/!ba;/$3/p;s/.. container:: only\n\n   $3\n\(.*\)\n.*/\1/g}" $2.tmp
         sed -i "/container:: only/{
           :a;N;/container:: endonly/!ba;//d}" $2.tmp
-
-        echo "VERSION: $3"
-        cat $2.tmp
-
 
         pandoc -s -f rst -t asciidoc $2.tmp -o $2
         rm -f $2.tmp 

--- a/scripts/docsascode/2asciidoc.sh
+++ b/scripts/docsascode/2asciidoc.sh
@@ -3,7 +3,7 @@
 
 # source yq_functions.sh
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
     echo "Illegal number of parameters"
     exit -1
 fi
@@ -49,6 +49,15 @@ case "$1" in
         sed -i -e "s/^\([ \t]*\).. container:: end_2cols/\1$twoColsEnd/g" $2.tmp        
 
         sed -i -e "s/:download:\`\(.*\)\`/\`\1\`_/g" $2.tmp
+
+        sed -i "/container:: only/{
+          :a;N;/container:: endonly/!ba;/$3/p;s/.. container:: only\n\n   $3\n\(.*\)\n.*/\1/}" $2.tmp
+        sed -i "/container:: only/{
+          :a;N;/container:: endonly/!ba;//d}" $2.tmp
+
+        echo "VERSION: $3"
+        cat $2.tmp
+
 
         pandoc -s -f rst -t asciidoc $2.tmp -o $2
         rm -f $2.tmp 

--- a/scripts/docsascode/2asciidoc.sh
+++ b/scripts/docsascode/2asciidoc.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 # set -xe
 
-source yq_functions.sh
+# source yq_functions.sh
 
 if [ "$#" -ne 2 ]; then
     echo "Illegal number of parameters"

--- a/scripts/docsascode/buildDoc.sh
+++ b/scripts/docsascode/buildDoc.sh
@@ -17,6 +17,7 @@ function cleanVar {
 function build_doc {
 
   local input_file=$1
+  local conditions=$2
 
   local pathname=$(cd "$(dirname "$input_file")"; pwd)/
   local filenameWithExtension=$(basename -- "$input_file")
@@ -93,7 +94,7 @@ function build_doc {
       source $current_output_template_path/build.dac
 
        # launch process
-      process $input_file $pathname $destination_folder $filenameNoExtension
+      process $input_file $pathname $destination_folder $filenameNoExtension $version
       postprocess $input_file $pathname $destination_folder $filenameNoExtension
 
        # clear temp folder

--- a/scripts/docsascode/plain_meta.tex
+++ b/scripts/docsascode/plain_meta.tex
@@ -7,3 +7,5 @@ $endif$
 $if(lang)$
 lang=$lang$
 $endif$
+version=$version$
+


### PR DESCRIPTION
Sphinx offers a directive called only that enables to have a conditionnal inclusion of the text.

This branch is implemeting that feature, by adding a keyword "version" in the document, that needs to receive the value that is neeeded.
Once it is done it is possible to use the only statement in the .. only:: directive in the document with the value that was provided to version.
Please note that it is needed to "close" that directive by using .. endonly:: at the end of the text that needs to be conditionally added.
[demo-only.txt](https://github.com/docascod/DocsAsCode/files/5278750/demo-only.txt)

