### PR TITLE
Use a fixed yq version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,7 +152,10 @@ RUN rm -rf /var/cache/apk/*
 
 
 # yq installation
-RUN wget $(curl -s https://api.github.com/repos/mikefarah/yq/releases/latest | grep browser_download_url | grep linux_amd64 | cut -d '"' -f 4) -O /usr/bin/yq && chmod +x /usr/bin/yq
+ARG yq_version=3.4.1
+ENV YQ_VERSION=${yq_version}
+RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq
+
 
 # ----- DocsAsCode -----
 


### PR DESCRIPTION
yq v4 is incompatible with v3 usage, docsascode needs to keep that
version until yq invocations are migrated.
